### PR TITLE
Use CSS hwb() for colors instead of converting to RGB

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In a flight case we have mounted some custom PCB's that can currently control up
 
 The `Edt-Vidt` is the _video_ part of the project; It displays a fullscreen `Vue` web application that can show videos/images/animations/text/colors/etc, controlled by the `Edt-Sledt` over a websocket connection. The app has a number of `presets` that each show something different on screen; check the code to see what is currently implemented.
 
-In our setup we are using 4 old 22" TV's that we bought at a second hand store and a 32" TV on a microphone stand, connected to a laptop with an 8 channel HDMI splitter, making it simple and reliable. It can even run on multiple laptops/computers and control even more screens, so it's pretty flexible depending on your needs.  
+In our setup we are using 4 old 22" TV's that we bought at a second hand store and a 32" TV on a microphone stand, connected to a laptop with an 8 channel HDMI splitter, making it simple and reliable. It can even run on multiple laptops/computers and control even more screens, so it's pretty flexible depending on your needs.
 
 ### Edt-Control
 
@@ -52,7 +52,8 @@ A bit of an unconventional name, we named the center of our system the `Sledt` (
 
 ## Concept
 
-Our current aim with the project is to: 
+Our current aim with the project is to:
+
 - make small/medium performances visually interesting with affordable DIY technology (for the price of 1 commercial DMX fixture you can create our whole setup)
 - rethink the way light shows are controlled by telling the system _how_ to respond to music, instead of directly controlling the lights (although this is also possible)
 - be able to setup the system in a venue in under 10 minutes; this is mostly done by packing everything in a flightcase and making it easy to connect
@@ -81,36 +82,45 @@ The core ideas of the Edt-2000 can be explained by looking at the folder structu
 
 ### Actions & 'RxJS store'
 
-The 3 main apps (Vidt, Control & Sledt) communicate using a shared RxJS based 'store', which each app includes in it's code and reacts to. The `Actions` are send over a socket connection to each other (see Input&Output folders) and converted into 'next' values for the various store observables. The `nextActionFromMsg()` function in the `Shared/actions.ts` file is the main function that is doing all the heavy lifting. 
+The 3 main apps (Vidt, Control & Sledt) communicate using a shared RxJS based 'store', which each app includes in it's code and reacts to. The `Actions` are send over a socket connection to each other (see Input&Output folders) and converted into 'next' values for the various store observables. The `nextActionFromMsg()` function in the `Shared/actions.ts` file is the main function that is doing all the heavy lifting.
 
 #### Communication
-This folder implements and exposes Observables like `OSC$` and `socket$` to use for other parts of the app. Originally we also included MIDI in here, but this was not reliable enough on multiple operating systems and is now coming into the system through OSC as well with an external app (in `Processing`). Using OSC for midi also means we can at some point create an Arduino based hardware midi-osc device to make setting up the system easier. 
+
+This folder implements and exposes Observables like `OSC$` and `socket$` to use for other parts of the app. Originally we also included MIDI in here, but this was not reliable enough on multiple operating systems and is now coming into the system through OSC as well with an external app (in `Processing`). Using OSC for midi also means we can at some point create an Arduino based hardware midi-osc device to make setting up the system easier.
 
 #### Inputs & Outputs
+
 These folders implement and expose functions/Observables for communicating with other parts of the system, like the Pedal, Trak, Vidt, Ledt, Control, Audio and MIDI. They convert signals from for instance `OSC$` and expose them again as an `EdtAudio$` observable, holding the information for that stream.
 
 For the `Vidt` for instance you will also find a number of subscriptions that send values from the RxJS store to the Vidt, where it is send to the `nextActionFromMsg()` function to be converted into `next` values: `this.socket.on('toVidt', nextActionFromMsg);`. By using shared TypeScript declarations we typecast these actions making working with the values effortless in all three apps (Vue, Angular, Node).
 
 #### Presets
+
 The preset section is where the `inputs` (can be anything) are converted into `outputs` (can also be anything). The presets all follow a common structure (see `preset-logic.ts`):
+
 ```typescript
 export abstract class PresetLogic {
-    ...
+...
     readonly modifierOptions: IModifierOptions;
     title: string = this.constructor.name;
     modifier = 127;
-    ...
-    startPreset(modifier: number) {}
-    stopPreset() {}
+...
+
+    startPreset(modifier: number) {
+    }
+
+    stopPreset() {
+    }
 }
 ```
 
-Presets can be started and stopped, and when started also get a `modifier` value. The `modifierOptions` are used for the `Edt-Control` to display a quick list of options, and `title` is identify each preset. 
+Presets can be started and stopped, and when started also get a `modifier` value. The `modifierOptions` are used for the `Edt-Control` to display a quick list of options, and `title` is identify each preset.
 
 Starting and stopping presets is controlled by `Actions.presetChange()`, which currently comes from the `Edt-Control` only. Originally this was also controllable by midi, and will at some point be re-implemented from the `MIDI$` observable so it can be automated.
 
 ##### Converters
- The whole system is build around streams of actions, leveraging RxJS to build chains of reactions. This is best explained with a simplified example (check the code for details): 
+
+The whole system is build around streams of actions, leveraging RxJS to build chains of reactions. This is best explained with a simplified example (check the code for details):
 
 ```typescript
 // ------------------------------
@@ -126,45 +136,47 @@ noteOn$
 // Then we map a specific note to a certain sound (snare, kick, hi-hat open) and re-trigger it as mainDrumSound for that specific sound (this.sound)
 // This is 
 // drumSoundMap.ts
-Actions$.mainDrum
-    .pipe(filter(drumNote => this.modifier === drumNote.note))
-    .subscribe(() => {
-        nextActionFromMsg(Actions.mainDrumSound(this.sound));
-    }),
+    Actions$.mainDrum
+        .pipe(filter(drumNote => this.modifier === drumNote.note))
+        .subscribe(() => {
+            nextActionFromMsg(Actions.mainDrumSound(this.sound));
+        }),
 
 // ------------------------------
 // In this converter we determine that every drumSound of a certain type (kick, snare, hi-hat, etc) needs to be converted to a 'beat' with a velocity
 // drumSoundToBeat.ts
-Actions$.mainDrumSound
-    .pipe(filter(drum => drum === this.modifier))
-    .subscribe(beat => {
-        nextActionFromMsg(Actions.mainBeat(beat));
-    }),
+    Actions$.mainDrumSound
+        .pipe(filter(drum => drum === this.modifier))
+        .subscribe(beat => {
+            nextActionFromMsg(Actions.mainBeat(beat));
+        }),
 
 // ------------------------------
 // In another converter we then convert every mainBeat to a new single color that is re-triggered 
 // beatToColor.ts
-Actions$.mainBeat
-    .pipe(withLatestFrom(Actions$.multiColor))
-    .subscribe(([, colors]) => {
-        this.index = (this.index + 1) % colors.length;
-        nextActionFromMsg(Actions.singleColor(colors[this.index]));
-    }), 
+    Actions$.mainBeat
+        .pipe(withLatestFrom(Actions$.multiColor))
+        .subscribe(([, colors]) => {
+            this.index = (this.index + 1) % colors.length;
+            nextActionFromMsg(Actions.singleColor(colors[this.index]));
+        }),
 
 // ------------------------------
 // And finally, to do something with this changing color we send it to all FastLED's with the Spark effect 
 // colorToFastLedSpark.ts
-Actions$.singleColor.subscribe(color => {
-    FastLedtSpark(0, color, this.modifier);
-}),
+    Actions$.singleColor.subscribe(color => {
+        FastLedtSpark(0, color, this.modifier);
+    }),
 ```
 
 As you see from the code snippets above, it takes 5 active presets to do a simple conversion from MIDI drum to sparkling LEDs. When we started this project this was done more in a hard-coded way, but we soon discovered that every song had different midi mappings, sometimes in music the `KICK` is not the `mainBeat`, etc. Over time we added more fine controls to have more flexibility, at the cost of having more presets.
 
 #### Cues
+
 As you can imagine, it is not feasible to activate 5 presets at the same time during a live performance. This is where the `cues` play a role; these are programmable shortcuts to trigger multiple presets with specific settings at the same time. These are currently hard-coded into the system; at some point they would ideally be editable from the program itself and saved somehow.
 
 An example cue could be:
+
 ```typescript
 export const drumCues = [
     {
@@ -205,12 +217,12 @@ You can send any `action` with this system, so more complex sets can be made to 
 
 ### Images / Assets
 
-For the `Edt-Vidt`, you can use your own assets by placing them in the `TypeScript/Edt-Vidt/public/assets/media-by-group` folder, in subfolders which then become the title of the `asset-group`. For instance: `TypeScript/Edt-Vidt/public/assets/media-by-group/SongTitle/001.jpg` will give you an asset called 001 in the content group `SongTitle`.  
-
+For the `Edt-Vidt`, you can use your own assets by placing them in the `TypeScript/Edt-Vidt/public/assets/media-by-group` folder, in subfolders which then become the title of the `asset-group`. For instance: `TypeScript/Edt-Vidt/public/assets/media-by-group/SongTitle/001.jpg` will give you an asset called 001 in the content group `SongTitle`.
 
 ## Using the system
+
 The system is quite complex and consists of many parts that all have to be configured to 'see' each other on a network. We currently hard-code IP addresses into the code; these configuration files can be found in the `Shared` folder. If you plan to use this system for your own performance, take a look at those files and adjust where needed.
- 
+
 Almost every piece of code is currently work in progress, as we are trying to make the system more modular and easier to extend/adjust without having to hardcode settings that make it hard to update/merge. Please get in touch if you are interested in using the sytem, so we can help! Our goal is to make it easy for everyone to run their own light-show and build their own hardware, and create tutorials on how to build the LED strips etc.
 
 To be continued! 

--- a/TypeScript/Edt-Controller/src/app/components/launchpad-grid/launchpad-grid.component.ts
+++ b/TypeScript/Edt-Controller/src/app/components/launchpad-grid/launchpad-grid.component.ts
@@ -34,7 +34,7 @@ export class LaunchpadGridComponent {
 
     getColorString(colors: IColor[] | any): SafeStyle {
         if (colors.every(isColorType)) {
-            return ColorHelper.getRGBString(colors) as SafeStyle;
+            return ColorHelper.getHwbString(colors) as SafeStyle;
         } else {
             return '';
         }

--- a/TypeScript/Edt-Controller/src/app/components/trigger-button/trigger-button.component.ts
+++ b/TypeScript/Edt-Controller/src/app/components/trigger-button/trigger-button.component.ts
@@ -25,6 +25,6 @@ export class TriggerButtonComponent {
     ) {}
 
     getColorString(color: IColor): SafeStyle {
-        return ColorHelper.getRGBString([color]);
+        return ColorHelper.getHwbString([color]);
     }
 }

--- a/TypeScript/Edt-Controller/src/app/pages/active-presets-controller/active-presets-controller.component.ts
+++ b/TypeScript/Edt-Controller/src/app/pages/active-presets-controller/active-presets-controller.component.ts
@@ -59,7 +59,7 @@ export class ActivePresetsControllerComponent {
                 timeredToZero,
                 map((velocity) => {
                     const brightness = mapInput(velocity, 0, 127, 0, 255);
-                    return ColorHelper.getRGBString([
+                    return ColorHelper.getHwbString([
                         { h: 255, b: brightness, s: 255 },
                     ]);
                 }),
@@ -75,7 +75,7 @@ export class ActivePresetsControllerComponent {
 
         Actions$.singleColor
             .pipe(
-                map((color) => ColorHelper.getRGBString([color])),
+                map((color) => ColorHelper.getHwbString([color])),
                 tap((color) => {
                     document.documentElement.style.setProperty(
                         '--node__SINGLECOLOR',
@@ -90,7 +90,7 @@ export class ActivePresetsControllerComponent {
             .pipe(
                 map(({ sound, velocity }) => {
                     const brightness = mapInput(velocity, 0, 127, 0, 255);
-                    const color = ColorHelper.getRGBString([
+                    const color = ColorHelper.getHwbString([
                         { h: 255, b: brightness, s: 255 },
                     ]);
                     document.documentElement.style.setProperty(

--- a/TypeScript/Edt-Vidt/src/app/views/circles/circles.component.html
+++ b/TypeScript/Edt-Vidt/src/app/views/circles/circles.component.html
@@ -5,7 +5,7 @@
                 @for (subcircle of subcircles; track circleIndex; let circleIndex = $index) {
                     <div [style.--circle-animation-delay]="getDelay(poolIndex, circleIndex, (animationType$ | async))"
                          [style.--circle-animation-duration]="((baseTime$ | async) ?? 2) + 's'"
-                         [style.--circle-rgb]="subcircle.rgb.join(',')"
+                         [style.--circle-hwb]="subcircle.hwb"
                          class="circles__circle"
                     ></div>
                 }

--- a/TypeScript/Edt-Vidt/src/app/views/circles/circles.component.scss
+++ b/TypeScript/Edt-Vidt/src/app/views/circles/circles.component.scss
@@ -1,5 +1,5 @@
 :root {
-    --circle-rgb: 165, 42, 42;
+    --circle-hwb: 0 16% 35%;
     --circle-animation-duration: 2s;
     --circle-animation-delay: 0s;
     --circle-distance-horizontal: 2vw;
@@ -51,7 +51,7 @@
         animation: circle var(--circle-animation-duration) linear infinite;
         animation-delay: var(--circle-animation-delay);
         aspect-ratio: 1/1;
-        border: 3vh solid rgb(var(--circle-rgb));
+        border: 3vh solid hwb(var(--circle-hwb));
         border-radius: 50%;
         grid-area: 1 / 1;
         scale: 0;

--- a/TypeScript/Edt-Vidt/src/app/views/circles/circles.component.ts
+++ b/TypeScript/Edt-Vidt/src/app/views/circles/circles.component.ts
@@ -6,7 +6,7 @@ import { createFilledArray } from '../../../../../Shared/utils/utils';
 import { AnimationTypes } from '../../../../../Shared/vidt/animation';
 
 interface Circle {
-    rgb: number[];
+    hwb: string;
 }
 
 @Component({
@@ -29,11 +29,11 @@ export class CirclesComponent {
         map((colors) => {
             if (!colors || colors.length === 0) {
                 return [
-                    { rgb: [255, 23, 154] },
-                    { rgb: [255, 71, 0] },
-                    { rgb: [255, 255, 5] },
-                    { rgb: [5, 243, 254] },
-                    { rgb: [53, 3, 168] },
+                    { hwb: '326 9% 0%' },
+                    { hwb: '17 0% 0%' },
+                    { hwb: '60 2% 0%' },
+                    { hwb: '183 2% 0%' },
+                    { hwb: '258 1% 34%' },
                 ];
             }
 
@@ -43,18 +43,18 @@ export class CirclesComponent {
             for (let i = 0; i <= amount; i++) {
                 const colorIndex = i % colors.length;
                 circles.push({
-                    rgb: ColorHelper.hsv2rgb(colors[colorIndex]),
+                    hwb: ColorHelper.hsv2hwb(colors[colorIndex]),
                 });
             }
 
             return circles;
         }),
         startWith([
-            { rgb: [255, 23, 154] },
-            { rgb: [255, 71, 0] },
-            { rgb: [255, 255, 5] },
-            { rgb: [5, 243, 254] },
-            { rgb: [53, 3, 168] },
+            { hwb: '326 9% 0%' },
+            { hwb: '17 0% 0%' },
+            { hwb: '60 2% 0%' },
+            { hwb: '183 2% 0%' },
+            { hwb: '258 1% 34%' },
         ]),
     );
 

--- a/TypeScript/Edt-Vidt/src/app/views/color-background/color-background.component.ts
+++ b/TypeScript/Edt-Vidt/src/app/views/color-background/color-background.component.ts
@@ -25,7 +25,7 @@ export class ColorBackgroundComponent {
     }
 
     public setStyles(colors: IColor[]) {
-        const bcgColor = ColorHelper.getRGBString(colors);
+        const bcgColor = ColorHelper.getHwbString(colors);
         this.styles = {
             background: `${bcgColor}`,
         };

--- a/TypeScript/Edt-Vidt/src/app/views/color-blocks/color-blocks.component.ts
+++ b/TypeScript/Edt-Vidt/src/app/views/color-blocks/color-blocks.component.ts
@@ -44,8 +44,8 @@ export class ColorBlocksComponent {
 
     public colorRgbString$ = merge(this.singleColor$, this.multiColor$).pipe(
         map(({ front, back }) => ({
-            frontColor: ColorHelper.getRGBString([front]),
-            backColor: ColorHelper.getRGBString([back]),
+            frontColor: ColorHelper.getHwbString([front]),
+            backColor: ColorHelper.getHwbString([back]),
         })),
     );
 }

--- a/TypeScript/Edt-Vidt/src/app/views/color-glitch/color-glitch.component.ts
+++ b/TypeScript/Edt-Vidt/src/app/views/color-glitch/color-glitch.component.ts
@@ -35,7 +35,7 @@ export class ColorGlitchComponent {
     }
 
     public setColors(first: IColor, second: IColor) {
-        this.firstColor = `rgb(${ColorHelper.hsv2rgb(first).join(', ')})`;
-        this.secondColor = `rgb(${ColorHelper.hsv2rgb(second).join(', ')})`;
+        this.firstColor = `hwb(${ColorHelper.hsv2hwb(first)})`;
+        this.secondColor = `hwb(${ColorHelper.hsv2hwb(second)})`;
     }
 }

--- a/TypeScript/Edt-Vidt/src/app/views/color-twinkle/color-twinkle.component.ts
+++ b/TypeScript/Edt-Vidt/src/app/views/color-twinkle/color-twinkle.component.ts
@@ -34,7 +34,7 @@ export class ColorTwinkleComponent implements OnInit, OnDestroy {
 
     public setStyles(hsb: IColor) {
         this.styles = {
-            color: ColorHelper.getRGBString([hsb]),
+            color: ColorHelper.getHwbString([hsb]),
         };
     }
 }

--- a/TypeScript/Edt-Vidt/src/app/views/kaleido/kaleido.component.ts
+++ b/TypeScript/Edt-Vidt/src/app/views/kaleido/kaleido.component.ts
@@ -45,7 +45,7 @@ export class KaleidoComponent implements OnInit, OnDestroy {
         let colorIndex = 0;
 
         for (let i = 1; i <= this.hexagons; i++) {
-            const color = `rgb(${ColorHelper.hsv2rgb(colors[colorIndex]).join(', ')})`;
+            const color = `hwb(${ColorHelper.hsv2hwb(colors[colorIndex])})`;
             this.styles[`--kaleido-${i}`] = color;
 
             colorIndex++;

--- a/TypeScript/Edt-Vidt/src/app/views/karaoke/karaoke.component.ts
+++ b/TypeScript/Edt-Vidt/src/app/views/karaoke/karaoke.component.ts
@@ -49,7 +49,7 @@ export class KaraokeComponent implements OnInit, OnDestroy {
     }
 
     public setStyles(colors: IColor[]) {
-        const bcgColor = ColorHelper.getRGBString(colors);
+        const bcgColor = ColorHelper.getHwbString(colors);
 
         this.styles = {
             color: `${bcgColor}`,

--- a/TypeScript/Edt-Vidt/src/app/views/spectrum/spectrum.component.html
+++ b/TypeScript/Edt-Vidt/src/app/views/spectrum/spectrum.component.html
@@ -6,7 +6,7 @@
                     <div [style.--spectrum-animation-delay]="(columnIndex * ((baseTime$ | async) ?? 4) * (1 / columns.length) * getDelayModifier(barIndex, subbars.length) * -1) + 's'"
                          [style.--spectrum-animation-duration]="(((baseTime$ | async) ?? 4) / 2) + 's'"
                          [style.--spectrum-bar-height]="getBarHeight(barIndex) + '%'"
-                         [style.--spectrum-bar-rgb]="bar.rgb.join(',')"
+                         [style.--spectrum-bar-hwb]="bar.hwb"
                          class="spectrum__subbar"
                     ></div>
                 }

--- a/TypeScript/Edt-Vidt/src/app/views/spectrum/spectrum.component.scss
+++ b/TypeScript/Edt-Vidt/src/app/views/spectrum/spectrum.component.scss
@@ -2,7 +2,7 @@
     --spectrum-gap: 16px;
     --spectrum-column: 80px;
     --spectrum-radius: 80px;
-    --spectrum-bar-rgb: 165, 42, 42;
+    --spectrum-bar-hwb: 0 16% 35%;
     --spectrum-bar-height: 100%;
     --spectrum-shadow-blur: 0px;
     --spectrum-shadow-spread: 0px;
@@ -30,22 +30,22 @@
 
     &__subbar {
         animation: spectrum var(--spectrum-animation-duration) var(--spectrum-animation-delay) ease-in-out infinite alternate;
-        background: rgb(var(--spectrum-bar-rgb));
+        background: hwb(var(--spectrum-bar-hwb));
         border-radius: var(--spectrum-radius) var(--spectrum-radius) 0 0;
-        box-shadow: 0 0 var(--spectrum-shadow-blur) var(--spectrum-shadow-spread) rgba(var(--spectrum-bar-rgb), 0.4);
+        box-shadow: 0 0 var(--spectrum-shadow-blur) var(--spectrum-shadow-spread) hwb(var(--spectrum-bar-hwb) / 0.4);
         grid-area: bar;
         height: var(--spectrum-bar-height);
         transform-origin: center bottom;
         width: 100%;
 
         &:nth-child(2) {
-            --spectrum-bar-rgb: 255, 140, 0;
+            --spectrum-bar-hwb: 33 0% 0%;
             --spectrum-bar-height: 70%;
             height: 70%;
         }
 
         &:nth-child(3) {
-            --spectrum-bar-rgb: 255, 215, 0;
+            --spectrum-bar-hwb: 51 0% 0%;
 
             height: 50%;
         }

--- a/TypeScript/Edt-Vidt/src/app/views/spectrum/spectrum.component.ts
+++ b/TypeScript/Edt-Vidt/src/app/views/spectrum/spectrum.component.ts
@@ -29,11 +29,11 @@ export class SpectrumComponent implements OnInit, OnDestroy {
         startWith(4),
     );
 
-    public subbars$: Observable<{ rgb: number[] }[]> = Actions$.vidtMultiColor.pipe(
+    public subbars$: Observable<{ hwb: string }[]> = Actions$.vidtMultiColor.pipe(
         withLatestFrom(this.modifier$),
         map(([colors, modifier]) => {
             if (!colors || colors.length === 0 || modifier === 'spectrum--lava') {
-                return [{ rgb: [165, 42, 42] }, { rgb: [255, 140, 0] }, { rgb: [255, 215, 0] }];
+                return [{ hwb: '0 16% 35%' }, { hwb: '33 0% 0%' }, { hwb: '51 0% 0%' }];
             }
 
             // Set colors
@@ -42,12 +42,12 @@ export class SpectrumComponent implements OnInit, OnDestroy {
             const color3 = colors[2] ?? colors[0];
 
             return [
-                { rgb: ColorHelper.hsv2rgb(color1) },
-                { rgb: ColorHelper.hsv2rgb(color2) },
-                { rgb: ColorHelper.hsv2rgb(color3) },
+                { hwb: ColorHelper.hsv2hwb(color1) },
+                { hwb: ColorHelper.hsv2hwb(color2) },
+                { hwb: ColorHelper.hsv2hwb(color3) },
             ];
         }),
-        startWith([{ rgb: [165, 42, 42] }, { rgb: [255, 140, 0] }, { rgb: [255, 215, 0] }]),
+        startWith([{ hwb: '0 16% 35%' }, { hwb: '33 0% 0%' }, { hwb: '51 0% 0%' }]),
     );
 
     public styles: Record<string, string> = {};

--- a/TypeScript/Edt-Vidt/src/app/views/wheel/wheel.component.ts
+++ b/TypeScript/Edt-Vidt/src/app/views/wheel/wheel.component.ts
@@ -34,7 +34,7 @@ export class WheelComponent implements OnInit, OnDestroy {
     }
 
     public setColors(first: IColor, second: IColor) {
-        this.firstColor = ColorHelper.getRGBString([first]);
-        this.secondColor = ColorHelper.getRGBString([second]);
+        this.firstColor = ColorHelper.getHwbString([first]);
+        this.secondColor = ColorHelper.getHwbString([second]);
     }
 }

--- a/TypeScript/Shared/colors/converters.ts
+++ b/TypeScript/Shared/colors/converters.ts
@@ -2,23 +2,34 @@ import { mapInput } from '../utils/map-input';
 import { IColor } from './types';
 
 export class ColorHelper {
-    static getRGBString(hsvColors: IColor[]) {
-        const rgbColors = ColorHelper.hsvArray2RGBArray(hsvColors);
-
-        if (rgbColors.length === 1) {
-            return `rgb(${rgbColors[0].join(', ')})`;
+       static getHwbString(hsvColors: IColor[]) {
+        if (hsvColors.length === 1) {
+            return `hwb(${ColorHelper.hsv2hwb(hsvColors[0])})`;
         } else {
-            const totalColors: number = rgbColors.length;
+            const totalColors: number = hsvColors.length;
             let currentIndex: number = 0;
-            const colorArray = rgbColors.map((color) => {
+            const colorArray = hsvColors.map((color) => {
+                const channels = ColorHelper.hsv2hwb(color);
                 const percentage = (100 / totalColors) * currentIndex;
                 const percentageNext = (100 / totalColors) * ++currentIndex;
 
-                return `rgb(${color.join(', ')}) ${percentage}%, rgb(${color.join(', ')}) ${percentageNext}%`;
+                return `hwb(${channels}) ${percentage}%, hwb(${channels}) ${percentageNext}%`;
             });
 
             return `linear-gradient(90deg,${colorArray.join(', ')})`;
         }
+    }
+
+    // Returns the bare HWB channels ("h w% b%") for use inside hwb(...) / CSS custom properties.
+    // HSB maps onto HWB exactly: whiteness = (1 - s) * v, blackness = 1 - v, hue unchanged.
+    static hsv2hwb(hsv: IColor | undefined): string {
+        if (!hsv) return '0 0% 100%'; // black, matching hsv2rgb's [0,0,0]
+        const h = mapInput(hsv.h, 0, 255, 0, 360);
+        const s = hsv.s / 255;
+        const v = hsv.b / 255;
+        const w = (1 - s) * v * 100;
+        const bl = (1 - v) * 100;
+        return `${h} ${w}% ${bl}%`;
     }
 
     static getContraColor(hsvColor: IColor): IColor {
@@ -27,40 +38,5 @@ export class ColorHelper {
             s: hsvColor.s,
             b: hsvColor.b,
         };
-    }
-
-    static hsvArray2RGBArray(hsvColors: IColor[]) {
-        return hsvColors.map(ColorHelper.hsv2rgb);
-    }
-
-    static hsv2rgb(hsv: IColor | undefined): number[] {
-        if(!hsv) return [0,0,0]
-        const h = mapInput(hsv.h, 0, 255, 0, 360) / 60;
-        const s = hsv.s / 255;
-        let v = hsv.b / 255;
-        const hi = Math.floor(h) % 6;
-
-        const f = h - Math.floor(h);
-        const p = Math.floor(255 * v * (1 - s));
-        const q = Math.floor(255 * v * (1 - s * f));
-        const t = Math.floor(255 * v * (1 - s * (1 - f)));
-        v *= 255;
-
-        switch (hi) {
-            case 0:
-                return [v, t, p];
-            case 1:
-                return [q, v, p];
-            case 2:
-                return [p, v, t];
-            case 3:
-                return [p, q, v];
-            case 4:
-                return [t, p, v];
-            case 5:
-                return [v, p, q];
-            default:
-                return [v, t, p];
-        }
     }
 }


### PR DESCRIPTION
Add ColorHelper.hsv2hwb / getHwbString and migrate all Vidt and Controller views to emit hwb() color strings directly from the incoming HSB values, dropping the hsv->rgb conversion in the CSS path. HSB maps onto HWB exactly (whiteness = (1-s)*v, blackness = 1-v, hue unchanged).

circles/spectrum custom properties now carry hwb channels; spectrum's alpha shadow uses hwb(var(...) / 0.4).